### PR TITLE
Add support for diffview.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ With Lazy
         "aaronhallaert/advanced-git-search.nvim",
         config = function()
             require("telescope").load_extension("advanced_git_search")
+
+            require("telescope").setup{
+                -- move this to the place where you call the telescope setup function
+                extensions = {
+                    advanced_git_search = {
+                        -- fugitive or diffview
+                        diff_plugin = "fugitive",
+                    }
+                }
+            }
         end,
         dependencies = {
             "nvim-telescope/telescope.nvim",
@@ -167,6 +177,16 @@ With Packer
         "aaronhallaert/advanced-git-search.nvim",
         config = function()
             require("telescope").load_extension("advanced_git_search")
+
+            require("telescope").setup{
+                -- move this to the place where you call the telescope setup function
+                extensions = {
+                    advanced_git_search = {
+                        -- fugitive or diffview
+                        diff_plugin = "fugitive",
+                    }
+                }
+            }
         end,
         requires = {
             "nvim-telescope/telescope.nvim",

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ vim.api.nvim_set_keymap(
 )
 ```
 
-
 #### _Keymaps_
 
 - `<CR>` opens a diff for the current file with the selected commit
@@ -154,9 +153,13 @@ With Lazy
             "nvim-telescope/telescope.nvim",
             -- to show diff splits and open commits in browser
             "tpope/vim-fugitive",
+            -- OPTIONAL: to replace the diff from fugitive with diffview.nvim
+            -- (fugitive is still needed to open in browser)
+            -- "sindrets/diffview.nvim",
         },
     }
 ```
+
 With Packer
 
 ```lua
@@ -169,6 +172,9 @@ With Packer
             "nvim-telescope/telescope.nvim",
             -- to show diff splits and open commits in browser
             "tpope/vim-fugitive",
+            -- OPTIONAL: to replace the diff from fugitive with diffview.nvim
+            -- (fugitive is still needed to open in browser)
+            -- "sindrets/diffview.nvim",
         },
     })
 ```
@@ -177,4 +183,5 @@ With Packer
 
 - git
 - vim-fugitive
+- sindrets/diffview.nvim
 - telescope.nvim

--- a/lua/advanced_git_search/git_utils.lua
+++ b/lua/advanced_git_search/git_utils.lua
@@ -2,6 +2,7 @@ local file = require("advanced_git_search.utils.file")
 local utils = require("advanced_git_search.utils")
 local finders = require("telescope.finders")
 local previewers = require("telescope.previewers")
+local config = require("advanced_git_search.utils.config")
 
 local last_prompt = nil
 local M = {}
@@ -202,29 +203,20 @@ M.open_diff_view = function(
     commit, --[[optional]]
     file_name
 )
-    if
-        vim.fn.exists(":DiffviewOpen") == 0
-        and vim.fn.exists(":Gvdiffsplit") == 0
-    then
-        vim.notify(
-            "Could not open diff: diffview.nvim or git-fugitive is not installed",
-            vim.log.levels.ERROR,
-            { title = "Advanced Git Search" }
-        )
-    end
+    local diff_plugin = config.diff_plugin()
 
     if file_name ~= nil and file_name ~= "" then
-        if vim.fn.exists(":DiffviewOpen") > 0 then
+        if diff_plugin == "diffview" then
             vim.api.nvim_command(
                 ":DiffviewOpen " .. commit .. " -- " .. file_name
             )
-        elseif vim.fn.exists(":Gvdiffsplit") > 0 then
+        elseif diff_plugin == "fugitive" then
             vim.api.nvim_command(":Gvdiffsplit " .. commit .. ":" .. file_name)
         end
     else
-        if vim.fn.exists(":DiffviewOpen") > 0 then
+        if diff_plugin == "diffview" then
             vim.api.nvim_command(":DiffviewOpen " .. commit)
-        elseif vim.fn.exists(":Gvdiffsplit") > 0 then
+        elseif diff_plugin == "fugitive" then
             vim.api.nvim_command(":Gvdiffsplit " .. commit)
         end
     end

--- a/lua/advanced_git_search/git_utils.lua
+++ b/lua/advanced_git_search/git_utils.lua
@@ -202,10 +202,31 @@ M.open_diff_view = function(
     commit, --[[optional]]
     file_name
 )
+    if
+        vim.fn.exists(":DiffviewOpen") == 0
+        and vim.fn.exists(":Gvdiffsplit") == 0
+    then
+        vim.notify(
+            "Could not open diff: diffview.nvim or git-fugitive is not installed",
+            vim.log.levels.ERROR,
+            { title = "Advanced Git Search" }
+        )
+    end
+
     if file_name ~= nil and file_name ~= "" then
-        vim.api.nvim_command(":Gvdiffsplit " .. commit .. ":" .. file_name)
+        if vim.fn.exists(":DiffviewOpen") > 0 then
+            vim.api.nvim_command(
+                ":DiffviewOpen " .. commit .. " -- " .. file_name
+            )
+        elseif vim.fn.exists(":Gvdiffsplit") > 0 then
+            vim.api.nvim_command(":Gvdiffsplit " .. commit .. ":" .. file_name)
+        end
     else
-        vim.api.nvim_command(":Gvdiffsplit " .. commit)
+        if vim.fn.exists(":DiffviewOpen") > 0 then
+            vim.api.nvim_command(":DiffviewOpen " .. commit)
+        elseif vim.fn.exists(":Gvdiffsplit") > 0 then
+            vim.api.nvim_command(":Gvdiffsplit " .. commit)
+        end
     end
 end
 

--- a/lua/advanced_git_search/utils/config.lua
+++ b/lua/advanced_git_search/utils/config.lua
@@ -1,0 +1,48 @@
+local M = {}
+
+local config = {}
+
+M.setup = function(ext_config)
+    ext_config = ext_config or {}
+
+    ext_config.diff_plugin = ext_config.diff_plugin or "fugitive"
+
+    config = ext_config
+end
+
+M.get_config = function()
+    return config
+end
+
+M.diff_plugin = function()
+    local diff_plugin = config["diff_plugin"]
+
+    if diff_plugin == "fugitive" and vim.fn.exists(":Gvdiffsplit") == 0 then
+        vim.notify(
+            "fugitive configured but git-fugitive is not installed",
+            vim.log.levels.ERROR,
+            { title = "Advanced Git Search" }
+        )
+        return nil
+    elseif
+        diff_plugin == "diffview" and vim.fn.exists(":DiffviewOpen") == 0
+    then
+        vim.notify(
+            "diffview configured but diffview.nvim is not installed",
+            vim.log.levels.ERROR,
+            { title = "Advanced Git Search" }
+        )
+        return nil
+    elseif diff_plugin == nil then
+        vim.notify(
+            "No diff plugin configured",
+            vim.log.levels.ERROR,
+            { title = "Advanced Git Search" }
+        )
+        return nil
+    end
+
+    return diff_plugin
+end
+
+return M

--- a/lua/telescope/_extensions/advanced_git_search.lua
+++ b/lua/telescope/_extensions/advanced_git_search.lua
@@ -1,6 +1,10 @@
 local func = require("advanced_git_search")
+local config = require("advanced_git_search.utils.config")
 
 return require("telescope").register_extension({
+    setup = function(ext_config, _)
+        config.setup(ext_config)
+    end,
     exports = {
         checkout_reflog = func.checkout_reflog,
         diff_branch_file = func.diff_branch_file,


### PR DESCRIPTION
* Support diffview.nvim
* Allow configuration of the used diff plugin.

Note: Fugitive is still required to open commits in the browser