### PR TITLE
Fix diff_branch_file quotes format

### DIFF
--- a/lua/advanced_git_search/commands/find.lua
+++ b/lua/advanced_git_search/commands/find.lua
@@ -4,11 +4,20 @@ local git_utils = require("advanced_git_search.utils.git")
 -- Specify shell commands for each finders in table format
 local M = {}
 
-M.git_branches = function()
+M.git_branches = function(opts)
+    opts = opts or { format_with_quotes = false }
+
+    local format
+    if opts["format_with_quotes"] then
+        format = "--format='%(refname:short)'"
+    else
+        format = "--format=%(refname:short)"
+    end
+
     return {
         "git",
         "branch",
-        "--format='%(refname:short)'",
+        format,
     }
 end
 

--- a/lua/advanced_git_search/fzf/pickers/init.lua
+++ b/lua/advanced_git_search/fzf/pickers/init.lua
@@ -145,7 +145,9 @@ M.diff_branch_file = function()
 
     require("fzf-lua").fzf_exec(
         table.concat(
-            require("advanced_git_search.commands.find").git_branches(),
+            require("advanced_git_search.commands.find").git_branches({
+                format_with_quotes = true,
+            }),
             " "
         ),
         opts


### PR DESCRIPTION
Fzf job requires quotes for git `format` option, Telescope doesn't