### PR TITLE
docs: example config lazy loads the plugin for lazy.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ To complete this snippet, see [Config](#Config) and [Dependencies](#Dependencies
 ```lua
 {
     "aaronhallaert/advanced-git-search.nvim",
+    cmd = { "AdvancedGitSearch" },
     config = function()
         -- optional: setup telescope before loading the extension
         require("telescope").setup{
@@ -250,6 +251,7 @@ To complete this snippet, see [Config](#Config) and [Dependencies](#Dependencies
 ```lua
 {
     "aaronhallaert/advanced-git-search.nvim",
+    cmd = { "AdvancedGitSearch" },
     config = function()
         require("advanced_git_search.fzf").setup{
             -- Insert Config here


### PR DESCRIPTION
Adding this causes lazy.nvim to load the plugin when the command is executed. The default is to load the plugin when nvim is started.

It seems to work fine for me, but I'm not sure if all the features work correctly.

See here for the docs:

https://github.com/folke/lazy.nvim?tab=readme-ov-file#-plugin-spec

I enabled it like this in my personal config: https://github.com/mikavilpas/dotfiles/commit/017cb2b4d65aa610eeefb2e560cd475bdf563fd5