### PR TITLE
feat: Add custom browse command support

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Enable `show_builtin_git_pickers` to additionally show builtin git pickers.
 
 ```lua
 {
+    -- Browse command to open commits in browser. Default fugitive GBrowse.
+    browse_command = "GBrowse",
     -- fugitive or diffview
     diff_plugin = "fugitive",
     -- customize git in previewer

--- a/lua/advanced_git_search/actions.lua
+++ b/lua/advanced_git_search/actions.lua
@@ -55,7 +55,7 @@ end
 ---General action: Open commit in browser
 ---@param commit_hash string
 M.open_in_browser = function(commit_hash)
-    vim.api.nvim_command(":GBrowse " .. commit_hash)
+    vim.api.nvim_command(":" .. config.get_browse_command() .. commit_hash)
 end
 
 ---General action: Checkout commit

--- a/lua/advanced_git_search/utils/config.lua
+++ b/lua/advanced_git_search/utils/config.lua
@@ -5,6 +5,7 @@ local config = {}
 M.setup = function(ext_config)
     ext_config = ext_config or {}
 
+    ext_config.browse_command = ext_config.browse_command or "GBrowse"
     ext_config.diff_plugin = ext_config.diff_plugin or "fugitive"
     ext_config.git_diff_flags = ext_config.git_diff_flags or {}
     ext_config.show_builtin_git_pickers = ext_config.show_builtin_git_pickers
@@ -162,6 +163,10 @@ end
 
 M.show_builtin_git_pickers = function()
     return config["show_builtin_git_pickers"]
+end
+
+M.get_browse_command = function()
+    return config["browse_command"]
 end
 
 return M


### PR DESCRIPTION
The changes introduced in this commit allow users to specify a custom command for browsing commits in a browser.