### PR TITLE
fix: keymap configuration not working in fzf picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Enable `show_builtin_git_pickers` to additionally show builtin git pickers.
         toggle_date_author = "<C-w>",
         open_commit_in_browser = "<C-o>",
         copy_commit_hash = "<C-y>",
+        show_entire_commit = "<C-e>",
     }
 
     -- Telescope layout setup

--- a/lua/advanced_git_search/fzf/mappings/init.lua
+++ b/lua/advanced_git_search/fzf/mappings/init.lua
@@ -4,12 +4,13 @@ local utils = require("advanced_git_search.utils")
 local global_actions = require("advanced_git_search.actions")
 local file_utils = require("advanced_git_search.utils.file")
 local git_utils = require("advanced_git_search.utils.git")
+local config = require("advanced_git_search.utils.config")
 
 ---FZF: <C-w> Toggle date or author in picker entry
 ---@return table
 M.toggle_entry_value = function()
     return {
-        ["ctrl-w"] = {
+        [config.get_keymap("toggle_date_author") or "ctrl-w"] = {
             fn = function(_, _)
                 require("advanced_git_search.fzf.pickers.utils").toggle_show_date_instead_of_author()
             end,
@@ -22,7 +23,10 @@ end
 ---@return table
 M.open_commit_in_brower = function()
     return {
-        ["ctrl-o"] = function(selected, _)
+        [config.get_keymap("open_commit_in_browser") or "ctrl-o"] = function(
+            selected,
+            _
+        )
             local selection = selected[1]
             local hash = utils.split_string(selection, " ")[1]
 
@@ -52,7 +56,10 @@ end
 ---@return table
 M.show_entire_commit = function()
     return {
-        ["ctrl-e"] = function(selected, _)
+        [config.get_keymap("show_entire_commit") or "ctrl-e"] = function(
+            selected,
+            _
+        )
             local selection = selected[1]
             local commit_hash = utils.split_string(selection, " ")[1]
 
@@ -84,7 +91,10 @@ end
 ---@return table
 M.copy_commit_hash = function()
     return {
-        ["ctrl-y"] = function(selected, _)
+        [config.get_keymap("copy_commit_hash") or "ctrl-y"] = function(
+            selected,
+            _
+        )
             local selection = selected[1]
             local commit_hash = utils.split_string(selection, " ")[1]
 

--- a/lua/advanced_git_search/telescope/mappings/init.lua
+++ b/lua/advanced_git_search/telescope/mappings/init.lua
@@ -89,7 +89,7 @@ end
 
 --- open entire commit diff with <C-e>
 M.show_entire_commit = function(map)
-    omnimap(map, "<C-e>", open_entire_commit)
+    omnimap(map, config.get_keymap("show_entire_commit"), open_entire_commit)
 end
 
 -------------------------------------------------------------------------------

--- a/lua/advanced_git_search/utils/config.lua
+++ b/lua/advanced_git_search/utils/config.lua
@@ -37,8 +37,7 @@ local function get_keymaps()
         toggle_date_author = "<C-w>",
         open_commit_in_browser = "<C-o>",
         copy_commit_hash = "<C-y>",
-        -- TODO: add new option to telescope picker and README. Change value to "<C-e>"
-        show_entire_commit = "ctrl-e",
+        show_entire_commit = "<C-e>",
     }
     keymaps = vim.tbl_extend("force", keymaps, config["keymaps"] or {})
 

--- a/lua/advanced_git_search/utils/config.lua
+++ b/lua/advanced_git_search/utils/config.lua
@@ -37,6 +37,8 @@ local function get_keymaps()
         toggle_date_author = "<C-w>",
         open_commit_in_browser = "<C-o>",
         copy_commit_hash = "<C-y>",
+        -- TODO: add new option to telescope picker and README. Change value to "<C-e>"
+        show_entire_commit = "ctrl-e",
     }
     keymaps = vim.tbl_extend("force", keymaps, config["keymaps"] or {})
 


### PR DESCRIPTION
This commit addresses the issue where the keymap configuration was not working as expected in the fzf picker.

Added new keymap config option "Show entire commit" for [FZF](https://github.com/ibhagwan/fzf-lua) picker only. 