### PR TITLE
docs: fix some readme links not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Enable `show_builtin_git_pickers` to additionally show builtin git pickers.
 
 <details>
 <summary>Lazy</summary>
+
 To complete this snippet, see [Config](#Config) and [Dependencies](#Dependencies).
 
 ```lua
@@ -255,6 +256,7 @@ use({
 
 <details>
 <summary>Lazy</summary>
+
 To complete this snippet, see [Config](#Config) and [Dependencies](#Dependencies).
 
 ```lua


### PR DESCRIPTION
I think they need to be separated from the previous line with `<summary>` tags in order to work.