### PR TITLE
feat: add "both" option to "entry_default_author_or_date

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ _Grep behaviour_: filter on added, updated or removed code (log content: `-G` op
 - `<C-e>` show the entire commit for all files in neovim with diff plugin
 - `<C-o>` Open the selected commit in the browser
 - `<C-y>` copy the commit hash to clipboard
-- `<C-w>` toggle date and author in entry
+- `<C-w>` cycle author, date and both in entry
 
 ### 2. search_log_content_file -- Search in file log content
 
@@ -50,7 +50,7 @@ _Grep behaviour_: filter on added, updated or removed code (log content: `-G` op
 - `<C-e>` show the entire commit for all files in neovim with diff plugin
 - `<C-o>` Open the selected commit in the browser
 - `<C-y>` copy the commit hash to clipboard
-- `<C-w>` toggle date and author in entry
+- `<C-w>` cycle author, date and both in entry
 
 ### 3. diff_commit_file -- Diff current file with commit
 
@@ -65,7 +65,7 @@ _Grep behaviour_: filter on commit message.
 - `<C-e>` show the entire commit for all files in neovim with diff plugin
 - `<C-o>` Open the selected commit in the browser
 - `<C-y>` copy the commit hash to clipboard
-- `<C-w>` toggle date and author in entry
+- `<C-w>` cycle author, date and both in entry
 
 ### 4. diff_commit_line -- Diff current file with selected line history
 
@@ -82,7 +82,7 @@ _Grep behaviour_: filter on commit message.
 - `<C-e>` show the entire commit for all files in neovim with diff plugin
 - `<C-o>` opens a the selected commit in the browser
 - `<C-y>` copy the commit hash to clipboard
-- `<C-w>` toggle date and author in entry
+- `<C-w>` cycle author, date and both in entry
 
 ### 5. diff_branch_file -- Diff file with branch
 
@@ -153,7 +153,7 @@ Enable `show_builtin_git_pickers` to additionally show builtin git pickers.
     git_log_flags = {},
     -- Show builtin git pickers when executing "show_custom_functions" or :AdvancedGitSearch
     show_builtin_git_pickers = false,
-    entry_default_author_or_date = "author", -- one of "author" or "date"
+    entry_default_author_or_date = "author", -- one of "author", "date" or "both"
     keymaps = {
         -- following keymaps can be overridden
         toggle_date_author = "<C-w>",

--- a/lua/advanced_git_search/fzf/mappings/init.lua
+++ b/lua/advanced_git_search/fzf/mappings/init.lua
@@ -6,7 +6,7 @@ local file_utils = require("advanced_git_search.utils.file")
 local git_utils = require("advanced_git_search.utils.git")
 local config = require("advanced_git_search.utils.config")
 
----FZF: <C-w> Toggle date or author in picker entry
+---FZF: <C-w> Cycle author/date/both in picker entry
 ---@return table
 M.toggle_entry_value = function()
     return {

--- a/lua/advanced_git_search/fzf/pickers/utils.lua
+++ b/lua/advanced_git_search/fzf/pickers/utils.lua
@@ -4,12 +4,24 @@ local config = require("advanced_git_search.utils.config")
 
 local M = {}
 
-local show_date_instead_of_author = (
-    config.entry_default_author_or_date() == "date"
-)
+local display_mode
+
+local function get_display_mode()
+    if not display_mode then
+        display_mode = config.entry_default_author_or_date()
+    end
+    return display_mode
+end
 
 M.toggle_show_date_instead_of_author = function()
-    show_date_instead_of_author = not show_date_instead_of_author
+    local mode = get_display_mode()
+    if mode == "author" then
+        display_mode = "date"
+    elseif mode == "date" then
+        display_mode = "both"
+    else
+        display_mode = "author"
+    end
 end
 
 M.make_entry = function(entry)
@@ -36,10 +48,15 @@ M.make_entry = function(entry)
     end
 
     -- NOTE: make sure the first value is the commit hash
+    local mode = get_display_mode()
     local final_entry
-    if show_date_instead_of_author then
+    if mode == "date" then
         final_entry = color.magenta(hash)
             .. color.cyan(" " .. date)
+            .. color.yellow(message)
+    elseif mode == "both" then
+        final_entry = color.magenta(hash)
+            .. color.cyan(" " .. date .. " @" .. author)
             .. color.yellow(message)
     else
         final_entry = color.magenta(hash)

--- a/lua/advanced_git_search/snacks/formatters.lua
+++ b/lua/advanced_git_search/snacks/formatters.lua
@@ -1,23 +1,43 @@
 local M = {}
+local config = require("advanced_git_search.utils.config")
 
 ---@return snacks.picker.format
 M.git_log = function()
     return function(item, picker)
         local a = Snacks.picker.util.align
+        local mode = config.entry_default_author_or_date()
 
         local ret = {} ---@type snacks.picker.Highlight[]
-        ret[#ret + 1] =
-            { picker.opts.icons.git.commit, "SnacksPickerGitCommit" }
+        ret[#ret + 1] = { picker.opts.icons.git.commit, "SnacksPickerGitCommit" }
         ret[#ret + 1] = {
             a(item.commit, 8, { truncate = true }),
             "SnacksPickerGitCommit",
         }
         ret[#ret + 1] = { " " }
-        ret[#ret + 1] = {
-            a(item.author, 15, { truncate = true }),
-            "SnacksPickerGitDate",
-        }
-        ret[#ret + 1] = { " " }
+        if mode == "date" then
+            ret[#ret + 1] = {
+                a(item.date, 10, { truncate = true }),
+                "SnacksPickerGitDate",
+            }
+            ret[#ret + 1] = { " " }
+        elseif mode == "both" then
+            ret[#ret + 1] = {
+                a(item.date, 10, { truncate = true }),
+                "SnacksPickerGitDate",
+            }
+            ret[#ret + 1] = { " " }
+            ret[#ret + 1] = {
+                a(item.author, 15, { truncate = true }),
+                "SnacksPickerGitDate",
+            }
+            ret[#ret + 1] = { " " }
+        else
+            ret[#ret + 1] = {
+                a(item.author, 15, { truncate = true }),
+                "SnacksPickerGitDate",
+            }
+            ret[#ret + 1] = { " " }
+        end
         ret[#ret + 1] = { item.msg, "SnacksPickerGitMsg" }
         return ret
     end

--- a/lua/advanced_git_search/telescope/finders/utils.lua
+++ b/lua/advanced_git_search/telescope/finders/utils.lua
@@ -2,15 +2,27 @@ local utils = require("advanced_git_search.utils")
 local entry_display = require("telescope.pickers.entry_display")
 local config = require("advanced_git_search.utils.config")
 
-local show_date_instead_of_author = (
-    config.entry_default_author_or_date() == "date"
-)
+local display_mode
+
+local function get_display_mode()
+    if not display_mode then
+        display_mode = config.entry_default_author_or_date()
+    end
+    return display_mode
+end
 
 local M = {}
 local last_prompt = nil
 
 M.toggle_show_date_instead_of_author = function()
-    show_date_instead_of_author = not show_date_instead_of_author
+    local mode = get_display_mode()
+    if mode == "author" then
+        display_mode = "date"
+    elseif mode == "date" then
+        display_mode = "both"
+    else
+        display_mode = "author"
+    end
 end
 
 --- Parse "--format=%C(auto)%h %as %C(green)%an _ %Creset %s" to table
@@ -37,41 +49,61 @@ M.git_log_entry_maker = function(entry)
         end
     end
 
-    local second_width
-    if show_date_instead_of_author then
-        second_width = 10
-    else
-        second_width = #author
-    end
+    local displayer
+    local make_display
+    local mode = get_display_mode()
 
-    local displayer = entry_display.create({
-        separator = " ",
-        items = {
-            { width = 7 },
-            { width = second_width },
-            { remaining = true },
-        },
-    })
-
-    local make_display = function(display_entry)
-        if show_date_instead_of_author then
+    if mode == "both" then
+        displayer = entry_display.create({
+            separator = " ",
+            items = {
+                { width = 7 },
+                { width = 10 },
+                { width = #author },
+                { remaining = true },
+            },
+        })
+        make_display = function(display_entry)
             return displayer({
                 {
                     display_entry.opts.commit_hash,
                     "TelescopeResultsIdentifier",
                 },
                 { display_entry.opts.date, "TelescopeResultsVariable" },
-                { display_entry.opts.message, "TelescopeResultsConstant" },
-            })
-        else
-            return displayer({
-                {
-                    display_entry.opts.commit_hash,
-                    "TelescopeResultsIdentifier",
-                },
                 { display_entry.opts.author, "TelescopeResultsVariable" },
                 { display_entry.opts.message, "TelescopeResultsConstant" },
             })
+        end
+    else
+        local second_width = mode == "date" and 10 or #author
+        displayer = entry_display.create({
+            separator = " ",
+            items = {
+                { width = 7 },
+                { width = second_width },
+                { remaining = true },
+            },
+        })
+        make_display = function(display_entry)
+            if mode == "date" then
+                return displayer({
+                    {
+                        display_entry.opts.commit_hash,
+                        "TelescopeResultsIdentifier",
+                    },
+                    { display_entry.opts.date, "TelescopeResultsVariable" },
+                    { display_entry.opts.message, "TelescopeResultsConstant" },
+                })
+            else
+                return displayer({
+                    {
+                        display_entry.opts.commit_hash,
+                        "TelescopeResultsIdentifier",
+                    },
+                    { display_entry.opts.author, "TelescopeResultsVariable" },
+                    { display_entry.opts.message, "TelescopeResultsConstant" },
+                })
+            end
         end
     end
 

--- a/lua/advanced_git_search/telescope/mappings/init.lua
+++ b/lua/advanced_git_search/telescope/mappings/init.lua
@@ -19,13 +19,14 @@ M.omnimap = omnimap
 
 -- create a local function and assign it to a map to get which_key description
 -------------------------------------------------------------------------------
-local toggle_date_author = function(prompt_bufnr)
+-- Telescope: <C-w> Cycle author/date/both in picker entry
+local cycle_date_author = function(prompt_bufnr)
     require("advanced_git_search.telescope.finders.utils").toggle_show_date_instead_of_author()
     action_state.get_current_picker(prompt_bufnr):refresh()
 end
 
 M.toggle_entry_value = function(map)
-    omnimap(map, config.get_keymap("toggle_date_author"), toggle_date_author)
+    omnimap(map, config.get_keymap("toggle_date_author"), cycle_date_author)
 end
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
##  PR: Cycle Author/Date Display Mode in Entries

### What Changed

* Added support for cycling **author → date → both → author** in picker entries with `<C-w>`.
* Updated mappings for both **fzf** and **telescope** integrations.
* Extended config option:

  ```lua
  entry_default_author_or_date = "author" -- now supports "author", "date", "both"
  ```
* Updated formatters for **fzf-lua**, **telescope**, and **snacks** pickers to respect the new display mode.
* Adjusted README to reflect the new behavior and configuration.

### Why

Previously `<C-w>` only toggled between author and date. This PR makes it more flexible by supporting **all three modes**, improving readability when browsing commits.

### Notes

* Default is still `"author"` for backward compatibility.
* README and keymap descriptions were updated accordingly.
